### PR TITLE
大佬，发现您的项目引入了com.fasterxml.jackson.core:jackson-databind@2.10.4组件，存在安全漏洞，提一个PR，建议升级修复

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,10 +13,7 @@
   ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
-  -->
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  --><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <modelVersion>4.0.0</modelVersion>
     <inceptionYear>2018</inceptionYear>
@@ -145,7 +142,7 @@
         <cglib-nodep.version>2.1</cglib-nodep.version>
         <jcip-annotations.version>1.0</jcip-annotations.version>
         <jackson-core.version>2.10.4</jackson-core.version>
-        <jackson-databind.version>2.10.4</jackson-databind.version>
+        <jackson-databind.version>2.10.5.1</jackson-databind.version>
         <jackson-core-asl.version>1.9.13</jackson-core-asl.version>
         <jjwt.version>0.11.2</jjwt.version>
         <netty-all.version>4.1.42.Final</netty-all.version>
@@ -1053,4 +1050,3 @@
         </repository>
     </distributionManagement>
 </project>
-


### PR DESCRIPTION
本次提交修复的漏洞信息:
```
漏洞标题：FasterXML jackson-databind 代码问题漏洞
缺陷组件：com.fasterxml.jackson.core:jackson-databind@2.10.4
漏洞编号：CVE-2020-25649
漏洞描述：FasterXML jackson-databind是一个基于JAVA可以将XML和JSON等数据格式与JAVA对象进行转换的库。Jackson可以轻松的将Java对象转换成json对象和xml文档，同样也可以将json、xml转换成Java对象。
FasterXML Jackson Databind存在代码问题漏洞，攻击者可利用该漏洞可以将恶意的XML数据传输到FasterXML Jackson Databind，以读取文件、扫描站点或触发拒绝服务。
影响范围：[2.10.0, 2.10.5.1)
最小修复版本：2.10.5.1
缺陷组件引入路径：com.alibaba.nacos:nacos-sys@1.4.1->com.alibaba.nacos:nacos-common@1.4.1->com.fasterxml.jackson.core:jackson-databind@2.10.4
```
另外我运行这个项目时，IDE的安全插件提示还有14个漏洞，我不确定升级是否会有兼容性问题。您有空的话可以查看报告修复下哈。感谢感谢。

相关漏洞详细报告：https://mofeisec.com/jr?p=pc2cc5